### PR TITLE
Update link to slack inviter

### DIFF
--- a/_themes/cakephp/layout.html
+++ b/_themes/cakephp/layout.html
@@ -239,7 +239,7 @@ as the macro in the base theme filters out jquery.
                 <a href="https://www.youtube.com/user/CakePHP" aria-label="Youtube" data-toggle="tooltip" title="Youtube"><i class="fa icon-social fa-youtube-play"></i></a>
                 <a href="https://www.linkedin.com/groups/4623165/profile" aria-label="Linkedin" target="_blank" title="" data-toggle="tooltip" data-original-title="Linkedin"><i class="fa icon-social fa-linkedin"></i></a>
                 <a href="https://github.com/cakephp" aria-label="Github" data-toggle="tooltip" title="Github"><i class="fa icon-social fa-git"></i></a>
-                <a href="https://cakesf.herokuapp.com/" aria-label="Slack" target="_blank" title="Slack" data-toggle="tooltip"><i class="fa fa-slack icon-social"></i></a>
+                <a href="https://slack-invite.cakephp.org/" aria-label="Slack" target="_blank" title="Slack" data-toggle="tooltip"><i class="fa fa-slack icon-social"></i></a>
                 <a href="https://stackoverflow.com/tags/cakephp" aria-label="Stack Overflow" data-toggle="tooltip" title="Stack Overflow"><i class="fa icon-social fa-stack-overflow"></i></a>
                 <a href="https://webchat.freenode.net/?channels=cakephp" aria-label="IRC" data-toggle="tooltip" title="IRC" class="icon-irc">#IRC</a>
             </div>


### PR DESCRIPTION
This application is moving to dokku as heroku is shutting down their free plans.